### PR TITLE
fix(init): use the correct argument for the public dir

### DIFF
--- a/init.js
+++ b/init.js
@@ -14,7 +14,7 @@ const REDIRECT_HTML_BUILD_PATH = path.resolve(
 
 const CWD = process.cwd();
 const args = process.argv.slice(2);
-const publicDir = args[0] || "./public";
+const publicDir = args[1] || "./public";
 
 // When running as a part of "postinstall" script, "cwd" equals the library's directory.
 // The "postinstall" script resolves the right absolute public directory path.


### PR DESCRIPTION
Originally:

```bash
$ npx @luciodale/temp init ./my-public-dir
Public directory does not exist!
```

Now:

```bash
$ npx @luciodale/temp init ./my-public-dir
Initializing the OAuth2 Service Worker at "./my-public-dir"...
oauth-service-worker successfully created!
oauth-redirect.html successfully created!
```