### PR TITLE
Fix some bugs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,7 +120,7 @@ export async function authorize(config: Config): Promise<void> {
 
 export async function registerOAuth2Worker(): Promise<void> {
   await navigator.serviceWorker
-    .register("./oauth-service-worker.js")
+    .register("/oauth-service-worker.js")
     .then(() => {
       console.log("Service worker registered");
       // we need this as a workaround to the fact that the service worker doesn't kick in with a hard refresh

--- a/src/oauth-service-worker.js
+++ b/src/oauth-service-worker.js
@@ -55,6 +55,10 @@ function createHeaders(headers, accessToken) {
   return newHeaders;
 }
 
+function getTimestampInSeconds () {
+  return Math.floor(Date.now() / 1000)
+}
+
 async function handleTokenResponse(response, configItem) {
   const { access_token, refresh_token, expires_in } = await response.json();
 
@@ -62,7 +66,7 @@ async function handleTokenResponse(response, configItem) {
   refreshTokenStore.set(configItem.origin, refresh_token);
   tokenExpirationStore.set(configItem.origin, {
     expires_in,
-    date: Date.now(),
+    date: getTimestampInSeconds(),
   });
 }
 
@@ -80,7 +84,7 @@ async function attachBearerToken(request, _clientId) {
   if (tokenStore.get(configItem.origin)) {
     const { expires_in, date } = tokenExpirationStore.get(configItem.origin);
 
-    if (Date.now() - date > expires_in) {
+    if (getTimestampInSeconds() - date > expires_in) {
       try {
         const response = await refreshToken(configItem);
         await handleTokenResponse(response, configItem);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 // Generate a secure random string using the browser crypto functions
 export function generateRandomString(): string {
-  const array = new Uint32Array(28);
+  const array = new Uint32Array(14);
   self.crypto.getRandomValues(array);
   return Array.from(array, (dec) =>
     ("0" + dec.toString(16)).substring(-2)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,11 +15,19 @@ function sha256(plain: string): Promise<ArrayBuffer> {
   return self.crypto.subtle.digest("SHA-256", data);
 }
 
+// Base64-urlencodes the input string
+function base64UrlEncode(str: string): string {
+  let bytes = Array.from(new Uint8Array(str));
+  let base64 = window.btoa(String.fromCharCode.apply(null, bytes));
+  return base64
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
 // Return the base64-urlencoded sha256 hash for the PKCE
 // challenge
 export async function pkceChallengeFromVerifier(v: string) {
   const hashed = await sha256(v);
-  let bytes = Array.from(new Uint8Array(hashed));
-  let base64 = window.btoa(String.fromCharCode.apply(null, bytes));
-  return base64;
+  return base64UrlEncode(hashed);
 }


### PR DESCRIPTION
Fixes the following bugs I found:

### Always load oauth-service-worker.js from the root of the host
I put in this fix because for our app, the user doesn't always load in at the root of the server.
If they're already at `example.com/app/admin` and they refresh the page this library would error because it was looking for the code in the wrong place.



### Make sure to URL-encode the base64 output for the PKCE challenge

I found that the base64 had some trailing `=` signs so I needed to URL-encode it



### Reduce the size of the code_verifier

OAuth (and Auth0) require that the code_verifier be between 43 and 128 characters.

Source: https://datatracker.ietf.org/doc/html/rfc7636#section-4.1


### Set the service worker to use seconds instead of milliseconds to calculate the expiry time

OAuth2 specifies that expires_in is in seconds: https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2
Date.now() is in milliseconds: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now